### PR TITLE
Support folder inputs and robust QR decoding

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,11 @@ shows each image sequentially so it can be scanned.
 ### Decode QR codes back into a file
 
 ```bash
-uv run qr decode qrs/archive_*.png --output restored.zip
+uv run qr decode qrs/ --output restored.zip
 ```
 
-The images are read, ordered automatically, and the original file is restored.
-If `--output` is omitted, the original filename embedded in the QR data is used.
+You can pass individual image paths or a directory containing the images. The
+images are read, ordered automatically, and the original file is restored.
+The decoder is tolerant of typical phone camera photos where the QR code does
+not perfectly fill the frame. If `--output` is omitted, the original filename
+embedded in the QR data is used.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,7 @@ dependencies = [
     "qrcode[pil]",
     "opencv-python-headless",
     "pillow",
+    "pyzbar",
 ]
 
 [project.scripts]

--- a/qr_tool/cli.py
+++ b/qr_tool/cli.py
@@ -60,20 +60,46 @@ def encode(
 
 @app.command()
 def decode(
-    images: List[Path] = typer.Argument(..., exists=True, dir_okay=False, readable=True),
+    images: List[Path] = typer.Argument(
+        ..., exists=True, readable=True, dir_okay=True
+    ),
     output: Path | None = typer.Option(None, help="Output file path."),
 ) -> None:
     """Decode QR code images back into the original file."""
     chunks: dict[int, bytes] = {}
     total_expected: int | None = None
 
+    # Gather all image paths, expanding directories.
+    image_paths: List[Path] = []
+    exts = {".png", ".jpg", ".jpeg", ".bmp", ".gif", ".tif", ".tiff"}
+    for p in images:
+        if p.is_dir():
+            for ext in exts:
+                image_paths.extend(sorted(p.glob(f"*{ext}")))
+        else:
+            image_paths.append(p)
+
+    if not image_paths:
+        raise typer.BadParameter("No image files provided")
+
     detector = cv2.QRCodeDetector()
-    for path in images:
+    try:
+        from pyzbar.pyzbar import decode as zbar_decode
+    except Exception:  # pragma: no cover - optional dependency
+        zbar_decode = None
+
+    for path in sorted(image_paths):
         img = cv2.imread(str(path))
         if img is None:
             raise typer.BadParameter(f"Could not read {path}")
         gray = cv2.cvtColor(img, cv2.COLOR_BGR2GRAY)
-        data, points, _ = detector.detectAndDecode(gray)
+        data, _, _ = detector.detectAndDecode(gray)
+        if not data:
+            data, _, _ = detector.detectAndDecode(img)
+        if not data and zbar_decode is not None:
+            decoded = zbar_decode(img)
+            if decoded:
+                data = decoded[0].data.decode("ascii")
         if not data:
             raise typer.BadParameter(f"Could not decode {path}")
         raw = base64.b64decode(data.encode("ascii"))

--- a/uv.lock
+++ b/uv.lock
@@ -203,12 +203,23 @@ wheels = [
 ]
 
 [[package]]
+name = "pyzbar"
+version = "0.1.9"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6d/24/81ebe6a1c00760471a3028a23cbe0b94e5fa2926e5ba47adc895920887bc/pyzbar-0.1.9-py2.py3-none-any.whl", hash = "sha256:4559628b8192feb25766d954b36a3753baaf5c97c03135aec7e4a026036b475d", size = 32560, upload-time = "2022-03-15T14:53:40.637Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/87/7b596730179ddf17857eea33ba820354dd4e1cf941e57f51ffccce26c409/pyzbar-0.1.9-py2.py3-none-win32.whl", hash = "sha256:8f4c5264c9c7c6b9f20d01efc52a4eba1ded47d9ba857a94130afe33703eb518", size = 810633, upload-time = "2022-03-15T14:53:43.446Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/e2/1c6a8e94197612dbdfc51eab8dfb674168829885fac2c4f50ac8366c25ca/pyzbar-0.1.9-py2.py3-none-win_amd64.whl", hash = "sha256:13e3ee5a2f3a545204a285f41814d5c0db571967e8d4af8699a03afc55182a9c", size = 817363, upload-time = "2022-03-15T14:53:46.691Z" },
+]
+
+[[package]]
 name = "qr"
 version = "0.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "opencv-python-headless" },
     { name = "pillow" },
+    { name = "pyzbar" },
     { name = "qrcode", extra = ["pil"] },
     { name = "typer" },
 ]
@@ -217,6 +228,7 @@ dependencies = [
 requires-dist = [
     { name = "opencv-python-headless" },
     { name = "pillow" },
+    { name = "pyzbar" },
     { name = "qrcode", extras = ["pil"] },
     { name = "typer" },
 ]


### PR DESCRIPTION
## Summary
- allow `qr decode` to accept directories and expand image files
- improve decode tolerance for phone photos and add pyzbar fallback
- document directory decoding and update dependencies

## Testing
- `uv run qr encode sample.txt --output-dir qrs --no-display`
- `uv run qr decode qrs/ --output restored.txt`
- `uv run qr decode phone.png --output restored_phone.txt`


------
https://chatgpt.com/codex/tasks/task_e_68a9f00256cc832c92636816e89a8d8d